### PR TITLE
feat: adicionando streaming de audio

### DIFF
--- a/fctepodcast-backend/src/app.ts
+++ b/fctepodcast-backend/src/app.ts
@@ -31,6 +31,12 @@ app.use(
         );
       }
     },
+    exposedHeaders: [
+      "Content-Range",
+      "Accept-Ranges",
+      "Content-Length",
+      "Content-Type",
+    ],
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     credentials: true,
   })

--- a/fctepodcast-backend/src/routes/file_router/file_router.ts
+++ b/fctepodcast-backend/src/routes/file_router/file_router.ts
@@ -1,0 +1,43 @@
+import express from "express";
+import fs from "fs";
+
+const file_router = express.Router();
+
+file_router.get("/status", (req, res) => {
+  res.status(200).json({
+    status: "ok",
+    message: "File router is running",
+  });
+});
+
+file_router.get("/audio/:file_path", (req, res) => {
+  const range = req.headers.range;
+  const filePath = req.params.file_path;
+  if (!range) {
+    res.status(400).send("Requires Range header");
+    return;
+  }
+
+  const audioSize = fs.statSync(filePath).size;
+
+  const CHUNK_SIZE = 10 ** 6; // 1MB
+  const start = Number(range.replace(/\D/g, ""));
+  const end = Math.min(start + CHUNK_SIZE, audioSize - 1);
+
+  const contentLength = end - start + 1;
+  const audioStream = fs.createReadStream(filePath, {
+    start,
+    end,
+  });
+
+  res.writeHead(206, {
+    "Content-Range": `bytes ${start}-${end}/${audioSize}`,
+    "Accept-Ranges": "bytes",
+    "Content-Length": contentLength,
+    "Content-Type": "audio/mpeg",
+  });
+
+  audioStream.pipe(res);
+});
+
+export default file_router;

--- a/fctepodcast-backend/src/routes/router.ts
+++ b/fctepodcast-backend/src/routes/router.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import usuario_router from "./usuario_router/usuario_router";
+import file_router from "./file_router/file_router";
 
 const router = express.Router();
 
@@ -15,5 +16,6 @@ router.get("/status", (req, res) => {
 // const imageProvider = new ImageAdapter(imageFileSystem);
 
 router.use("/usuario", usuario_router);
+router.use("/file", file_router);
 
 export default router;

--- a/fctepodcast-frontend/src/components/playbar/PlayBar.tsx
+++ b/fctepodcast-frontend/src/components/playbar/PlayBar.tsx
@@ -43,12 +43,41 @@ const PlayBar = () => {
   const [imageBlobUrl, setImageBlobUrl] = useState<string | null>(null);
   const [liked, setLiked] = useState<boolean>(false);
   const formatTime = (seconds: number) => {
-    const m = Math.floor(seconds / 60);
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
     const s = Math.floor(seconds % 60);
-    return `${m}:${s < 10 ? "0" : ""}${s}`;
+
+    if (h > 0) {
+      return `${h}:${m.toString().padStart(2, "0")}:${s
+        .toString()
+        .padStart(2, "0")}`;
+    } else {
+      return `${m}:${s.toString().padStart(2, "0")}`;
+    }
   };
   const [loadingLike, setLoadingLike] = useState<boolean>(false);
   const navigate = useNavigate();
+  const [isSeeking, setIsSeeking] = useState<boolean>(false);
+  const [sliderValue, setSliderValue] = useState<number>(0);
+
+  useEffect(() => {
+    if (!isSeeking) {
+      setSliderValue(currentTime);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentTime, duration]);
+
+  const handleSliderChange = (value: number | number[]) => {
+    if (typeof value === "number") {
+      setSliderValue(value);
+      seek(value);
+    }
+  };
+
+  const handleSliderRelease = () => {
+    seek(sliderValue);
+    setIsSeeking(false);
+  };
 
   const checkLiked = async () => {
     if (!episode_data?._id || !user?.id) return;
@@ -156,12 +185,6 @@ const PlayBar = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [episode_data]);
-
-  const handleSliderChange = (value: number | number[]) => {
-    if (typeof value === "number") {
-      seek(value);
-    }
-  };
 
   const handlePlay = () => {
     dispatchCommand(new PlayCommand(player));
@@ -283,16 +306,17 @@ const PlayBar = () => {
             <Slider
               aria-label="Tempo de reprodução"
               className="cursor-pointer"
-              defaultValue={[0]}
-              value={[currentTime]}
               minValue={0}
               maxValue={duration}
               step={0.1}
-              onChange={(value: number | number[]) =>
+              value={sliderValue}
+              onChange={(value) =>
                 Array.isArray(value)
                   ? handleSliderChange(value[0])
                   : handleSliderChange(value)
               }
+              onMouseUp={handleSliderRelease}
+              onTouchEnd={handleSliderRelease}
               size="sm"
             />
           )}


### PR DESCRIPTION
### 📋 Descrição

Adicionando streaming de audio, agora o audio não precisa ser totalmente carregado, fazendo streaming on demand


### 👩‍💻 Como foi testado?

Foram feitos testes manuais

### ✔️ Checklist

Marque com um "x" as caixas correspondentes:

- [x] Demais funcionalidades não foram afetadas
- [x] Streaming adequado, permitindo o envio de arquivos maiores.

### ✍🏻 Notas adicionais
Qualquer informação adicional que seja relevante:

Nada a adicionar